### PR TITLE
Fix wakeup from deep sleep

### DIFF
--- a/config/boards/shields/corax/corax.dtsi
+++ b/config/boards/shields/corax/corax.dtsi
@@ -22,6 +22,7 @@ RC(0,0) RC(2,0) RC(2,1) RC(2,2) RC(2,3) RC(2,4) RC(2,5)                 RC(2,6) 
 
     kscan0: kscan {
         compatible = "zmk,kscan-gpio-matrix";
+        wakeup-source;
     };
 
     encoder_left: encoder_left {


### PR DESCRIPTION
I've had issues with the keyboard halves not waking up from the deep sleep that I uncommented. Turns out that there's currently a small regression in ZMK due to a newly introduced feature. This commit fixes that as per the ZMK discord, see [announcement](https://discord.com/channels/719497620560543766/719544534500900886/1223354718005497988).